### PR TITLE
OpenCL GPU Diamonds Miner for x16rs

### DIFF
--- a/app/src/diaworker.rs
+++ b/app/src/diaworker.rs
@@ -1,4 +1,6 @@
-use std::sync::{Arc, RwLock, mpsc};
+use std::sync::{RwLock, mpsc};
+#[cfg(feature = "ocl")]
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering::*};
 
 use std::time::*;
@@ -16,12 +18,14 @@ use field::interface::*;
 use protocol::difficulty::*;
 use mint::genesis::*;
 use mint::action::*;
-use x16rs::diamond_hash;
 
 
 
 include!{"util.rs"}
-include!{"opencl.rs"}
+#[cfg(feature = "ocl")]
+include!{"opencl_common.rs"}
+#[cfg(feature = "ocl")]
+include!{"opencl_dia.rs"}
 
 
 
@@ -131,15 +135,19 @@ pub fn diaworker() {
     load_init(&mut cnf);
 
     // Initialize OpenCL
+    #[cfg(feature = "ocl")]
     let opencl_resources: Vec<OpenCLResources> = if cnf.useopencl {
         #[cfg(feature = "ocl")]
         { initialize_opencl(true, &cnf.opencldir, &cnf.platformid, &cnf.deviceids, &cnf.workgroups, &cnf.localsize, &cnf.unitsize) }
-        #[cfg(not(feature = "ocl"))]
-        Vec::new()
     } else {
         // No OpenCL miners
         Vec::new()
     };
+    // Calculate device/cpu quantity
+    #[cfg(feature = "ocl")]
+    let vene: u32 = if cnf.useopencl { opencl_resources.len() as u32 } else { cnf.supervene };
+    #[cfg(not(feature = "ocl"))]
+    let vene: u32 = cnf.supervene;
 
     // deal results
     let cnf1 = cnf.clone();
@@ -147,7 +155,7 @@ pub fn diaworker() {
         let mut most_dia_str = [b'W'; 16];
         let mut rstx = res_rx;
         loop {
-            deal_diamond_mining_results(&cnf1, &mut most_dia_str, &mut rstx);
+            deal_diamond_mining_results(&cnf1, &mut most_dia_str, &mut rstx, vene);
             delay_continue_ms!(77);
         }
     });
@@ -163,7 +171,23 @@ pub fn diaworker() {
                 let rstx: mpsc::Sender<DiamondMiningResult> = res_tx.clone();
                 spawn(move || {
                     loop {
-                        run_diamond_worker_thread(&cnf2, thrid, rstx.clone(), Some(opencl_clone.clone()));
+                        run_diamond_worker_thread_opencl(&cnf2, thrid, rstx.clone(), opencl_clone.clone());
+                        delay_continue_ms!(9);
+                    }
+                });
+            }
+        }
+        #[cfg(not(feature = "ocl"))]
+        {
+            println!("[Warning] use_opencl=true but app built without feature 'ocl'; fallback to CPU mining.");
+            let thrnum = cnf.supervene as usize;
+            println!("\n[Start] Create #{} diamond miner worker thread.", thrnum);
+            for thrid in 0 .. thrnum {
+                let cnf2: DiaWorkConf = cnf.clone();
+                let rstx: mpsc::Sender<DiamondMiningResult> = res_tx.clone();
+                spawn(move || {
+                    loop {
+                        run_diamond_worker_thread(&cnf2, thrid, rstx.clone());
                         delay_continue_ms!(9);
                     }
                 });
@@ -177,7 +201,7 @@ pub fn diaworker() {
             let rstx: mpsc::Sender<DiamondMiningResult> = res_tx.clone();
             spawn(move || {
                 loop {
-                    run_diamond_worker_thread(&cnf2, thrid, rstx.clone(), None);
+                    run_diamond_worker_thread(&cnf2, thrid, rstx.clone());
                     delay_continue_ms!(9);
                 }
             });
@@ -195,13 +219,8 @@ pub fn diaworker() {
 
 
 fn deal_diamond_mining_results(cnf: &DiaWorkConf, most_dia_str: &mut [u8; 16], 
-    result_ch_rx: &mut mpsc::Receiver<DiamondMiningResult>,
+    result_ch_rx: &mut mpsc::Receiver<DiamondMiningResult>, vene: u32,
 ) {
-    let vene = if cnf.useopencl {
-        1 // Single thread with GPU
-    } else {
-        cnf.supervene
-    };
     let mut deal_number = 0u32;
     let mut most = DiamondMiningResult::default();
     most.dia_str = [b'w'; 16];
@@ -262,7 +281,6 @@ fn may_print_turn_to_nex_diamond_mining(curr_number: u32, most_dia_str: Option<&
 // 
 fn run_diamond_worker_thread(cnf: &DiaWorkConf, _thrid: usize,
     result_ch_tx: mpsc::Sender<DiamondMiningResult>,
-    opencl: Option<Arc<OpenCLResources>>,
 ) {
     let cmdn = MINING_DIAMOND_NUM.load(Relaxed);
     if cmdn == 0 {
@@ -271,11 +289,7 @@ fn run_diamond_worker_thread(cnf: &DiaWorkConf, _thrid: usize,
 
     let rwd_addr = cnf.rewardaddr.clone();
 
-    let mut nonce_space: u64 = if !cnf.useopencl {
-        15000
-    } else {
-        (cnf.workgroups * cnf.localsize * cnf.unitsize) as u64
-    };
+    let mut nonce_space: u64 = 15000;
     let current_mining_number: u32 = cmdn;
     let current_mining_block_hash: Hash = {
         MINING_DIAMOND_STUFF.read().unwrap().clone()
@@ -289,53 +303,20 @@ fn run_diamond_worker_thread(cnf: &DiaWorkConf, _thrid: usize,
     loop {
 
         let ctn = Instant::now();
-
-        #[cfg(not(feature = "ocl"))]
-        let mut result = do_diamond_group_mining(current_mining_number, &current_mining_block_hash,
-                &rwd_addr, &custom_nonce,
-                nonce_start, nonce_space, 
-            );
-
         // println!("- nonce_start: {}", nonce_start);
-        #[cfg(feature = "ocl")]
-        let mut result = if cnf.useopencl {
-            let opencl = opencl
-                .as_ref()
-                .expect("OpenCL miner is disabled");
-            do_diamond_group_mining_opencl(
-                &opencl,
-                current_mining_number,
-                &current_mining_block_hash,
-                &rwd_addr,
-                &custom_nonce,
-                nonce_start,
-                nonce_space,
-                cnf.workgroups,
-                cnf.localsize,
-                cnf.unitsize,
-            )
-        } else {
-           do_diamond_group_mining(current_mining_number, &current_mining_block_hash,
-                &rwd_addr, &custom_nonce,
-                nonce_start, nonce_space, 
-            )
-        };
+        let result = do_diamond_group_mining(current_mining_number, &current_mining_block_hash,
+            &rwd_addr, &custom_nonce,
+            nonce_start, nonce_space, 
+        );
+        // println!("do_diamond_group_mining: {:?}", &result);
         let use_secs = Instant::now().duration_since(ctn).as_millis() as f64 / 1000.0;
-        result.use_secs = use_secs;
         result_ch_tx.send(result).unwrap(); // channel send
-        if !cnf.useopencl { // nonce space is always the same in opencl
-            // update space
-            nonce_space = (nonce_space as f64 * MINING_INTERVAL / use_secs) as u64;
-        }
         let ns = nonce_start.checked_add(nonce_space);
         if let None = ns {
             break // u64 nonce end
         }
         nonce_start = ns.unwrap();
-         if !cnf.useopencl { // nonce space is always the same in opencl
-            // update space
-            nonce_space = ( nonce_space as f64 / use_secs * MINING_INTERVAL ) as u64;
-        }
+        nonce_space = ( nonce_space as f64 / use_secs * MINING_INTERVAL ) as u64;
 
         // check next
         if current_mining_number < MINING_DIAMOND_NUM.load(Relaxed) {
@@ -344,6 +325,57 @@ fn run_diamond_worker_thread(cnf: &DiaWorkConf, _thrid: usize,
 
     }
 
+}
+
+#[cfg(feature = "ocl")]
+fn run_diamond_worker_thread_opencl(cnf: &DiaWorkConf, _thrid: usize,
+    result_ch_tx: mpsc::Sender<DiamondMiningResult>,
+    opencl: Arc<OpenCLResources>,
+) {
+    let cmdn = MINING_DIAMOND_NUM.load(Relaxed);
+    if cmdn == 0 {
+        delay_return_ms!(99); // not yet
+    }
+
+    let rwd_addr = cnf.rewardaddr.clone();
+    let nonce_space: u64 = (cnf.workgroups * cnf.localsize * cnf.unitsize) as u64;
+    let current_mining_number: u32 = cmdn;
+    let current_mining_block_hash: Hash = {
+        MINING_DIAMOND_STUFF.read().unwrap().clone()
+    };
+
+    let mut custom_nonce = Hash::default();
+    getrandom::fill(custom_nonce.as_mut()).unwrap();
+    let mut nonce_start = 0;
+
+    loop {
+        let ctn = Instant::now();
+        let mut result = do_diamond_group_mining_opencl(
+            &opencl,
+            current_mining_number,
+            &current_mining_block_hash,
+            &rwd_addr,
+            &custom_nonce,
+            nonce_start,
+            nonce_space,
+            cnf.workgroups,
+            cnf.localsize,
+            cnf.unitsize,
+        );
+        let use_secs = Instant::now().duration_since(ctn).as_millis() as f64 / 1000.0;
+        result.use_secs = use_secs;
+        result_ch_tx.send(result).unwrap();
+
+        let ns = nonce_start.checked_add(nonce_space);
+        if let None = ns {
+            break
+        }
+        nonce_start = ns.unwrap();
+
+        if current_mining_number < MINING_DIAMOND_NUM.load(Relaxed) {
+            return
+        }
+    }
 }
 
 
@@ -398,123 +430,6 @@ fn do_diamond_group_mining(number: u32, prevblockhash: &Hash,
         diamint.d.address = rwdaddr.clone();
         diamint.d.custom_message = custom_message.clone();
         most.is_success = Some(diamint); // mark success
-    }
-    // ok
-    most
-}
-
-fn do_diamond_group_mining_opencl(
-    opencl: &OpenCLResources,
-    number: u32,
-    prevblockhash: &Hash, 
-    rwdaddr: &Address,
-    custom_message: &Hash,
-    nonce_start: u64,
-    nonce_space: u64,
-    num_work_groups: u32,
-    local_work_size: u32,
-    unit_size: u32,
-) -> DiamondMiningResult {
-    let empthbytes = [0u8; 0];
-    let prevhash: &[u8; HASH_WIDTH] = prevblockhash;
-    let address: &[u8; 21] = rwdaddr;
-    let custom_nonce: &[u8] = match number > DIAMOND_ABOVE_NUMBER_OF_CREATE_BY_CUSTOM_MESSAGE {
-        true => custom_message.as_bytes(),
-        false => &empthbytes,
-    };
-    let mut most = DiamondMiningResult {
-        number,
-        nonce_start,
-        nonce_space,
-        u64_nonce: 0,
-        msg_nonce: custom_nonce.to_vec(),
-        dia_str: [b'W'; 16],
-        is_success: None,
-        use_secs: 0.0,
-    };
-    let global_work_size = num_work_groups * local_work_size;
-    let repeat = x16rs::mine_diamond_hash_repeat(number) as u32;
-    let stuff = [
-        prevhash.to_vec(),
-        [0u8; 8].to_vec(),
-        address.to_vec(),
-        custom_nonce.as_ref().to_vec(),
-    ].concat();
-
-    let buffer_block_intro = Buffer::<u8>::builder()
-        .queue(opencl.queue.clone())
-        .flags(ocl::core::MEM_READ_ONLY)
-        .len(stuff.len())
-        .copy_host_slice(&stuff)
-        .build()
-        .expect("Unable to create buffer_block_intro");
-
-    let kernel = Kernel::builder()
-        .program(&opencl.program)
-        .name("x16rs_diamond")
-        .queue(opencl.queue.clone())
-        .global_work_size(global_work_size)
-        .local_work_size(local_work_size)
-        .arg(&buffer_block_intro)
-        .arg(nonce_start)
-        .arg(repeat)
-        .arg(unit_size)
-        .arg(&opencl.buffer_global_hashes)
-        .arg(&opencl.buffer_global_order)
-        .arg(&opencl.buffer_best_hashes)
-        .arg(&opencl.buffer_best_nonces_diamond)
-        .build()
-        .unwrap();
-
-    let mut kernel_event = EventList::new();
-    unsafe {
-        kernel.cmd().enew(&mut kernel_event).enq().expect("Unable to queue OpenCL kernel");
-    }
-
-    let mut hashes = vec![0u8; opencl.buffer_best_hashes.len()];
-    opencl.buffer_best_hashes
-        .read(&mut hashes)
-        .ewait(&kernel_event)
-        .enq()
-        .expect("Can't read buffer_best_hashes");
-
-    let mut nonces = vec![0u64; opencl.buffer_best_nonces_diamond.len()];
-    opencl.buffer_best_nonces_diamond
-        .read(&mut nonces)
-        .ewait(&kernel_event)
-        .enq()
-        .expect("Can't read buffer_best_nonces_diamond");
-
-    for i in 0..num_work_groups as usize {
-        let hash_bytes = &hashes[i * 32..(i * 32) + 32].try_into().unwrap();
-        let dia_str = diamond_hash(&hash_bytes);
-        let nonce_bytes = nonces[i].to_be_bytes(); // [u8; 4]
-        // println!("nonce_bytes: {:?}", nonce_bytes);
-        let stuff = [
-            prevblockhash.as_slice(),
-            nonce_bytes.as_slice(),
-            address.as_slice(),
-            custom_message.as_ref(),
-        ].concat();
-        // get ssshash by sha3 algrotithm
-        let ssshash: [u8; 32] = calculate_hash(stuff); // SHA3
-        
-        if let Some(dia_name) = check_diamer_success(number, ssshash, *hash_bytes, dia_str) {
-            let name = DiamondName::from(dia_name);
-            let number = DiamondNumber::from(number);
-            let mut diamint = DiamondMint::with(name, number);
-            diamint.d.prev_hash = prevblockhash.clone();
-            diamint.d.nonce = Fixed8::from(nonces[i].to_be_bytes());
-            diamint.d.address = rwdaddr.clone();
-            diamint.d.custom_message = custom_message.clone();
-            most.dia_str = dia_str;
-            most.u64_nonce = nonces[i];
-            most.is_success = Some(diamint); // mark success
-            return most; // already found
-        } else if diamond_more_power(&dia_str, &most.dia_str) {
-            most.dia_str = dia_str;
-            most.u64_nonce = nonces[i];
-        }
     }
     // ok
     most

--- a/app/src/diaworker.rs
+++ b/app/src/diaworker.rs
@@ -1,4 +1,4 @@
-use std::sync::{RwLock, mpsc};
+use std::sync::{Arc, RwLock, mpsc};
 use std::sync::atomic::{AtomicU32, Ordering::*};
 
 use std::time::*;
@@ -16,10 +16,12 @@ use field::interface::*;
 use protocol::difficulty::*;
 use mint::genesis::*;
 use mint::action::*;
+use x16rs::diamond_hash;
 
 
 
 include!{"util.rs"}
+include!{"opencl.rs"}
 
 
 
@@ -38,6 +40,14 @@ pub struct DiaWorkConf {
     pub supervene: u32, // cpu core
     pub bidaddr: Address,
     pub rewardaddr: Address,
+    pub useopencl: bool, // use opencl miner
+    pub workgroups: u32, // opencl work groups
+    pub localsize: u32, // opencl work units per work group
+    pub unitsize: u32, // opencl hashes per work unit
+    pub opencldir: String, // opencl source dir
+    pub debug: u32, // enable debug mode
+    pub platformid: u32, // opencl platform id
+    pub deviceids: String, // opencl device id list
 }
 
 
@@ -45,11 +55,20 @@ impl DiaWorkConf {
 
     pub fn new(ini: &IniObj) -> DiaWorkConf {
         let sec = &ini_section(ini, "default"); // default = root
+        let sec_gpu = &ini_section(ini, "gpu");
         let cnf = DiaWorkConf{
             rpcaddr: ini_must(sec, "connect", "127.0.0.1:8081"),
             supervene: ini_must_u64(sec, "supervene", 2) as u32,
             bidaddr: Address::default(),
             rewardaddr: Address::default(),
+            useopencl: ini_must_bool(sec_gpu, "use_opencl", false) as bool,
+            workgroups: ini_must_u64(sec_gpu, "work_groups", 1024) as u32,
+            localsize: ini_must_u64(sec_gpu, "local_size", 256) as u32,
+            unitsize: ini_must_u64(sec_gpu, "unit_size", 128) as u32,
+            opencldir: ini_must(sec_gpu, "opencl_dir", "opencl/"),
+            debug: ini_must_u64(sec_gpu, "debug", 0) as u32,
+            platformid: ini_must_u64(sec_gpu, "platform_id", 0) as u32,
+            deviceids: ini_must(sec_gpu, "device_ids", "")
         };
         cnf
     }
@@ -87,6 +106,7 @@ struct DiamondMiningResult {
     msg_nonce: Vec<u8>,
     dia_str: [u8; 16],
     is_success: Option<DiamondMint>,
+    use_secs: f64,
 }
 
 
@@ -110,6 +130,17 @@ pub fn diaworker() {
     // init
     load_init(&mut cnf);
 
+    // Initialize OpenCL
+    let opencl_resources: Vec<OpenCLResources> = if cnf.useopencl {
+        #[cfg(feature = "ocl")]
+        { initialize_opencl(true, &cnf.opencldir, &cnf.platformid, &cnf.deviceids, &cnf.workgroups, &cnf.localsize, &cnf.unitsize) }
+        #[cfg(not(feature = "ocl"))]
+        Vec::new()
+    } else {
+        // No OpenCL miners
+        Vec::new()
+    };
+
     // deal results
     let cnf1 = cnf.clone();
     spawn(move || {
@@ -121,18 +152,36 @@ pub fn diaworker() {
         }
     });
 
-    // start worker
-    let thrnum = cnf.supervene as usize;
-    println!("\n[Start] Create #{} diamond miner worker thread.", thrnum);
-    for thrid in 0 .. thrnum {
-        let cnf2 = cnf.clone();
-        let rstx = res_tx.clone();
-        spawn(move || {
-            loop {
-                run_diamond_worker_thread(&cnf2, thrid, rstx.clone());
-                delay_continue_ms!(9);
+    if cnf.useopencl { // opencl is enabled
+        #[cfg(feature = "ocl")]
+        {
+            // Initialize OpenCL
+            println!("\n[Start] Create GPU block miner worker");
+            for (thrid, opencl_thread) in opencl_resources.into_iter().enumerate() {
+                let opencl_clone = Arc::new(opencl_thread);
+                let cnf2 = cnf.clone();
+                let rstx: mpsc::Sender<DiamondMiningResult> = res_tx.clone();
+                spawn(move || {
+                    loop {
+                        run_diamond_worker_thread(&cnf2, thrid, rstx.clone(), Some(opencl_clone.clone()));
+                        delay_continue_ms!(9);
+                    }
+                });
             }
-        });
+        }
+    } else {
+        let thrnum = cnf.supervene as usize;
+        println!("\n[Start] Create #{} diamond miner worker thread.", thrnum);
+        for thrid in 0 .. thrnum {
+            let cnf2: DiaWorkConf = cnf.clone();
+            let rstx: mpsc::Sender<DiamondMiningResult> = res_tx.clone();
+            spawn(move || {
+                loop {
+                    run_diamond_worker_thread(&cnf2, thrid, rstx.clone(), None);
+                    delay_continue_ms!(9);
+                }
+            });
+        }
     }
 
     // pull loop
@@ -148,15 +197,21 @@ pub fn diaworker() {
 fn deal_diamond_mining_results(cnf: &DiaWorkConf, most_dia_str: &mut [u8; 16], 
     result_ch_rx: &mut mpsc::Receiver<DiamondMiningResult>,
 ) {
-    let vene = cnf.supervene;
+    let vene = if cnf.useopencl {
+        1 // Single thread with GPU
+    } else {
+        cnf.supervene
+    };
     let mut deal_number = 0u32;
     let mut most = DiamondMiningResult::default();
     most.dia_str = [b'w'; 16];
     let mut total_nonce_space = 0u64;
+    let mut total_use_secs = 0.0;
     for _ in 0 .. vene as usize {
-        let res = result_ch_rx.recv().unwrap();
+        let res: DiamondMiningResult = result_ch_rx.recv().unwrap();
         deal_number = res.number;
         total_nonce_space += res.nonce_space as u64;
+        total_use_secs += res.use_secs; // Accumulated total time
         if diamond_more_power(&res.dia_str, &most.dia_str) {
             most = res.clone();
         }
@@ -172,7 +227,12 @@ fn deal_diamond_mining_results(cnf: &DiaWorkConf, most_dia_str: &mut [u8; 16],
     // print hashrates
     let diastr = String::from_utf8(most.dia_str.to_vec()).unwrap();
     let most_diastr = String::from_utf8(most_dia_str.to_vec()).unwrap();
-    let hsrts = rates_to_show(total_nonce_space as f64 / MINING_INTERVAL);
+    let nonce_rates = if cnf.useopencl {
+        total_nonce_space as f64 / (total_use_secs / vene as f64)
+    } else {
+        total_nonce_space as f64 / MINING_INTERVAL
+    };
+    let hsrts = rates_to_show(nonce_rates);
     flush!("{} {}, {} {}, {}.        \r", 
         most.nonce_start, total_nonce_space, 
         diastr, most_diastr, hsrts
@@ -202,6 +262,7 @@ fn may_print_turn_to_nex_diamond_mining(curr_number: u32, most_dia_str: Option<&
 // 
 fn run_diamond_worker_thread(cnf: &DiaWorkConf, _thrid: usize,
     result_ch_tx: mpsc::Sender<DiamondMiningResult>,
+    opencl: Option<Arc<OpenCLResources>>,
 ) {
     let cmdn = MINING_DIAMOND_NUM.load(Relaxed);
     if cmdn == 0 {
@@ -210,7 +271,11 @@ fn run_diamond_worker_thread(cnf: &DiaWorkConf, _thrid: usize,
 
     let rwd_addr = cnf.rewardaddr.clone();
 
-    let mut nonce_space: u64 = 15000;
+    let mut nonce_space: u64 = if !cnf.useopencl {
+        15000
+    } else {
+        (cnf.workgroups * cnf.localsize * cnf.unitsize) as u64
+    };
     let current_mining_number: u32 = cmdn;
     let current_mining_block_hash: Hash = {
         MINING_DIAMOND_STUFF.read().unwrap().clone()
@@ -224,20 +289,53 @@ fn run_diamond_worker_thread(cnf: &DiaWorkConf, _thrid: usize,
     loop {
 
         let ctn = Instant::now();
+
+        #[cfg(not(feature = "ocl"))]
+        let mut result = do_diamond_group_mining(current_mining_number, &current_mining_block_hash,
+                &rwd_addr, &custom_nonce,
+                nonce_start, nonce_space, 
+            );
+
         // println!("- nonce_start: {}", nonce_start);
-        let result = do_diamond_group_mining(current_mining_number, &current_mining_block_hash,
-            &rwd_addr, &custom_nonce,
-            nonce_start, nonce_space, 
-        );
-        // println!("do_diamond_group_mining: {:?}", &result);
+        #[cfg(feature = "ocl")]
+        let mut result = if cnf.useopencl {
+            let opencl = opencl
+                .as_ref()
+                .expect("OpenCL miner is disabled");
+            do_diamond_group_mining_opencl(
+                &opencl,
+                current_mining_number,
+                &current_mining_block_hash,
+                &rwd_addr,
+                &custom_nonce,
+                nonce_start,
+                nonce_space,
+                cnf.workgroups,
+                cnf.localsize,
+                cnf.unitsize,
+            )
+        } else {
+           do_diamond_group_mining(current_mining_number, &current_mining_block_hash,
+                &rwd_addr, &custom_nonce,
+                nonce_start, nonce_space, 
+            )
+        };
         let use_secs = Instant::now().duration_since(ctn).as_millis() as f64 / 1000.0;
+        result.use_secs = use_secs;
         result_ch_tx.send(result).unwrap(); // channel send
+        if !cnf.useopencl { // nonce space is always the same in opencl
+            // update space
+            nonce_space = (nonce_space as f64 * MINING_INTERVAL / use_secs) as u64;
+        }
         let ns = nonce_start.checked_add(nonce_space);
         if let None = ns {
             break // u64 nonce end
         }
         nonce_start = ns.unwrap();
-        nonce_space = ( nonce_space as f64 / use_secs * MINING_INTERVAL ) as u64;
+         if !cnf.useopencl { // nonce space is always the same in opencl
+            // update space
+            nonce_space = ( nonce_space as f64 / use_secs * MINING_INTERVAL ) as u64;
+        }
 
         // check next
         if current_mining_number < MINING_DIAMOND_NUM.load(Relaxed) {
@@ -268,6 +366,7 @@ fn do_diamond_group_mining(number: u32, prevblockhash: &Hash,
         msg_nonce: custom_nonce.to_vec(),
         dia_str: [b'W'; 16],
         is_success: None,
+        use_secs: 0.0,
     };
     let mut most_firhx = [0u8; HASH_WIDTH];
     let mut most_resxh = [0u8; HASH_WIDTH];
@@ -304,6 +403,122 @@ fn do_diamond_group_mining(number: u32, prevblockhash: &Hash,
     most
 }
 
+fn do_diamond_group_mining_opencl(
+    opencl: &OpenCLResources,
+    number: u32,
+    prevblockhash: &Hash, 
+    rwdaddr: &Address,
+    custom_message: &Hash,
+    nonce_start: u64,
+    nonce_space: u64,
+    num_work_groups: u32,
+    local_work_size: u32,
+    unit_size: u32,
+) -> DiamondMiningResult {
+    let empthbytes = [0u8; 0];
+    let prevhash: &[u8; HASH_WIDTH] = prevblockhash;
+    let address: &[u8; 21] = rwdaddr;
+    let custom_nonce: &[u8] = match number > DIAMOND_ABOVE_NUMBER_OF_CREATE_BY_CUSTOM_MESSAGE {
+        true => custom_message.as_bytes(),
+        false => &empthbytes,
+    };
+    let mut most = DiamondMiningResult {
+        number,
+        nonce_start,
+        nonce_space,
+        u64_nonce: 0,
+        msg_nonce: custom_nonce.to_vec(),
+        dia_str: [b'W'; 16],
+        is_success: None,
+        use_secs: 0.0,
+    };
+    let global_work_size = num_work_groups * local_work_size;
+    let repeat = x16rs::mine_diamond_hash_repeat(number) as u32;
+    let stuff = [
+        prevhash.to_vec(),
+        [0u8; 8].to_vec(),
+        address.to_vec(),
+        custom_nonce.as_ref().to_vec(),
+    ].concat();
+
+    let buffer_block_intro = Buffer::<u8>::builder()
+        .queue(opencl.queue.clone())
+        .flags(ocl::core::MEM_READ_ONLY)
+        .len(stuff.len())
+        .copy_host_slice(&stuff)
+        .build()
+        .expect("Unable to create buffer_block_intro");
+
+    let kernel = Kernel::builder()
+        .program(&opencl.program)
+        .name("x16rs_diamond")
+        .queue(opencl.queue.clone())
+        .global_work_size(global_work_size)
+        .local_work_size(local_work_size)
+        .arg(&buffer_block_intro)
+        .arg(nonce_start)
+        .arg(repeat)
+        .arg(unit_size)
+        .arg(&opencl.buffer_global_hashes)
+        .arg(&opencl.buffer_global_order)
+        .arg(&opencl.buffer_best_hashes)
+        .arg(&opencl.buffer_best_nonces_diamond)
+        .build()
+        .unwrap();
+
+    let mut kernel_event = EventList::new();
+    unsafe {
+        kernel.cmd().enew(&mut kernel_event).enq().expect("Unable to queue OpenCL kernel");
+    }
+
+    let mut hashes = vec![0u8; opencl.buffer_best_hashes.len()];
+    opencl.buffer_best_hashes
+        .read(&mut hashes)
+        .ewait(&kernel_event)
+        .enq()
+        .expect("Can't read buffer_best_hashes");
+
+    let mut nonces = vec![0u64; opencl.buffer_best_nonces_diamond.len()];
+    opencl.buffer_best_nonces_diamond
+        .read(&mut nonces)
+        .ewait(&kernel_event)
+        .enq()
+        .expect("Can't read buffer_best_nonces_diamond");
+
+    for i in 0..num_work_groups as usize {
+        let hash_bytes = &hashes[i * 32..(i * 32) + 32].try_into().unwrap();
+        let dia_str = diamond_hash(&hash_bytes);
+        let nonce_bytes = nonces[i].to_be_bytes(); // [u8; 4]
+        // println!("nonce_bytes: {:?}", nonce_bytes);
+        let stuff = [
+            prevblockhash.as_slice(),
+            nonce_bytes.as_slice(),
+            address.as_slice(),
+            custom_message.as_ref(),
+        ].concat();
+        // get ssshash by sha3 algrotithm
+        let ssshash: [u8; 32] = calculate_hash(stuff); // SHA3
+        
+        if let Some(dia_name) = check_diamer_success(number, ssshash, *hash_bytes, dia_str) {
+            let name = DiamondName::from(dia_name);
+            let number = DiamondNumber::from(number);
+            let mut diamint = DiamondMint::with(name, number);
+            diamint.d.prev_hash = prevblockhash.clone();
+            diamint.d.nonce = Fixed8::from(nonces[i].to_be_bytes());
+            diamint.d.address = rwdaddr.clone();
+            diamint.d.custom_message = custom_message.clone();
+            most.dia_str = dia_str;
+            most.u64_nonce = nonces[i];
+            most.is_success = Some(diamint); // mark success
+            return most; // already found
+        } else if diamond_more_power(&dia_str, &most.dia_str) {
+            most.dia_str = dia_str;
+            most.u64_nonce = nonces[i];
+        }
+    }
+    // ok
+    most
+}
 
 fn check_diamer_success(number: u32, firhx: [u8; HASH_WIDTH], resxh: [u8; HASH_WIDTH], diastr: [u8; 16]) -> Option<[u8; 6]> {
     if let None = x16rs::check_diamond_hash_result(&diastr) {

--- a/app/src/opencl.rs
+++ b/app/src/opencl.rs
@@ -2,7 +2,6 @@ use std::ffi::CString;
 use std::path::Path;
 use std::fs::{self, File};
 use std::io::{Read, Write};
-use ocl::core::QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE;
 use ocl::enums::{ProgramInfoResult, ProgramInfo};
 use ocl::{Buffer, Context, Device, EventList, Kernel, Platform, Program, Queue};
 
@@ -10,20 +9,29 @@ struct OpenCLResources {
     program: Program,
     queue: Queue,
     buffer_best_nonces: Buffer::<u32>,
+    buffer_best_nonces_diamond: Buffer::<u64>,
     buffer_global_hashes: Buffer::<u8>,
     buffer_global_order: Buffer::<u32>,
     buffer_best_hashes: Buffer::<u8>,
 }
 
-fn initialize_opencl(cnf: &PoWorkConf) -> Vec<OpenCLResources> {
+fn initialize_opencl(
+    diamond_mining: bool,
+    opencldir: &String,
+    platformid: &u32,
+    deviceids: &String,
+    workgroups: &u32,
+    localsize: &u32,
+    unitsize: &u32,
+) -> Vec<OpenCLResources> {
     // Binary file location
-    let kernel_file = format!(r"{}x16rs_main.cl", cnf.opencldir);
+    let kernel_file = if diamond_mining { format!(r"{}x16rs_diamond.cl", opencldir) } else { format!(r"{}x16rs_main.cl", opencldir) };
     let kernel_path = Path::new(&kernel_file);
 
     // Context creation for OpenCL instance
     let platforms = Platform::list();
     let platform = platforms
-        .get(cnf.platformid as usize)
+        .get(*platformid as usize)
         .expect("The specified platform id is invalid")
         .clone();
 
@@ -34,7 +42,7 @@ fn initialize_opencl(cnf: &PoWorkConf) -> Vec<OpenCLResources> {
     println!("Manufacturer: {}", vendor);
     println!("Version: {}", version);
 
-    let mut cnf_devices: Vec<u32> = cnf.deviceids.split(',')
+    let mut cnf_devices: Vec<u32> = deviceids.split(',')
         .filter(|s| !s.trim().is_empty())
         .filter_map(|s| s.trim().parse::<u32>().ok())
         .collect();
@@ -55,7 +63,7 @@ fn initialize_opencl(cnf: &PoWorkConf) -> Vec<OpenCLResources> {
         devices.push(device);
     }
 
-    let num_work_items = cnf.workgroups * cnf.localsize;
+    let num_work_items = workgroups * localsize;
     let global_work_size = num_work_items;
 
     let mut opencl_resource_devices = Vec::with_capacity(devices.len() as usize);
@@ -73,12 +81,12 @@ fn initialize_opencl(cnf: &PoWorkConf) -> Vec<OpenCLResources> {
             .build()
             .expect("Can't create OpenCL context");
 
-        if !Path::new(&cnf.opencldir).is_dir() {
-            panic!("OpenCL dir not found: {}", cnf.opencldir);
+        if !Path::new(&opencldir).is_dir() {
+            panic!("OpenCL dir not found: {}", opencldir);
         }
 
         let device_name = device.name().expect("Can't get device name");
-        let binary_file = format!(r"{}{}_{}.bin", cnf.opencldir, device_name, cnf_devices[idx]);
+        let binary_file = format!(r"{}{}_{}{}.bin", opencldir, device_name, cnf_devices[idx], if diamond_mining { "_diamond" } else { "" });
         let binary_path = Path::new(&binary_file);
 
         // Check if kernel was changed since last time (and need recompile)
@@ -113,7 +121,7 @@ fn initialize_opencl(cnf: &PoWorkConf) -> Vec<OpenCLResources> {
         } else {
             println!("Compiling...");
             // Compile from source
-            compile_program_from_source(&context, &device, &kernel_path, &binary_path, cnf.opencldir.clone())
+            compile_program_from_source(&context, &device, &kernel_path, &binary_path, opencldir.clone())
         };
         
         // Create new queue
@@ -126,25 +134,31 @@ fn initialize_opencl(cnf: &PoWorkConf) -> Vec<OpenCLResources> {
             buffer_best_nonces: Buffer::<u32>::builder()
                 .queue(queue.clone())
                 .flags(ocl::core::MEM_WRITE_ONLY)
-                .len(cnf.workgroups)
+                .len(*workgroups)
                 .build()
                 .expect("Can't create buffer_best_nonces"),
+            buffer_best_nonces_diamond: Buffer::<u64>::builder()
+                .queue(queue.clone())
+                .flags(ocl::core::MEM_WRITE_ONLY)
+                .len(*workgroups)
+                .build()
+                .expect("Can't create buffer_best_nonces_diamond"),
             buffer_global_hashes: Buffer::<u8>::builder()
                 .queue(queue.clone())
                 .flags(ocl::core::MEM_READ_WRITE)
-                .len(HASH_WIDTH * cnf.unitsize as usize * global_work_size as usize)
+                .len(HASH_WIDTH * *unitsize as usize * global_work_size as usize)
                 .build()
                 .expect("Can't create buffer_global_hashes"),
             buffer_global_order: Buffer::<u32>::builder()
                 .queue(queue.clone())
                 .flags(ocl::core::MEM_READ_WRITE)
-                .len(cnf.unitsize as usize * global_work_size as usize)
+                .len(*unitsize as usize * global_work_size as usize)
                 .build()
                 .expect("Can't create buffer_global_order"),
             buffer_best_hashes: Buffer::<u8>::builder()
                 .queue(queue.clone())
                 .flags(ocl::core::MEM_WRITE_ONLY)
-                .len(HASH_WIDTH * cnf.workgroups as usize )
+                .len(HASH_WIDTH * *workgroups as usize )
                 .build()
                 .expect("Can't create buffer_best_hashes")
         });

--- a/app/src/opencl_common.rs
+++ b/app/src/opencl_common.rs
@@ -5,6 +5,7 @@ use std::io::{Read, Write};
 use ocl::enums::{ProgramInfoResult, ProgramInfo};
 use ocl::{Buffer, Context, Device, EventList, Kernel, Platform, Program, Queue};
 
+#[allow(dead_code)]
 struct OpenCLResources {
     program: Program,
     queue: Queue,
@@ -86,7 +87,7 @@ fn initialize_opencl(
         }
 
         let device_name = device.name().expect("Can't get device name");
-        let binary_file = format!(r"{}{}_{}{}.bin", opencldir, device_name, cnf_devices[idx], if diamond_mining { "_diamond" } else { "" });
+        let binary_file = format!(r"{}{}_{}{}.bin", opencldir, device_name, cnf_devices[idx], if diamond_mining { "_diamonds" } else { "" });
         let binary_path = Path::new(&binary_file);
 
         // Check if kernel was changed since last time (and need recompile)
@@ -223,71 +224,3 @@ fn compile_program_from_source(
     program
 }
 
-fn do_group_block_mining_opencl(
-    opencl: &OpenCLResources,
-    height: u64,
-    block_intro: Vec<u8>,
-    nonce_start: u32,
-    num_work_groups: u32,
-    local_work_size: u32,
-    unit_size: u32,
-) -> (u32, [u8; 32]) {
-    let mut most_nonce = 0u32;
-    let mut most_hash = [255u8; 32];
-    let global_work_size = num_work_groups * local_work_size;
-    let repeat = x16rs::block_hash_repeat(height) as u32;
-
-    let buffer_block_intro = Buffer::<u8>::builder()
-        .queue(opencl.queue.clone())
-        .flags(ocl::core::MEM_READ_ONLY)
-        .len(block_intro.len())
-        .copy_host_slice(&block_intro)
-        .build()
-        .expect("Unable to create buffer_block_intro");
-
-    let kernel = Kernel::builder()
-        .program(&opencl.program)
-        .name("x16rs_main")
-        .queue(opencl.queue.clone())
-        .global_work_size(global_work_size)
-        .local_work_size(local_work_size)
-        .arg(&buffer_block_intro)
-        .arg(nonce_start)
-        .arg(repeat)
-        .arg(unit_size)
-        .arg(&opencl.buffer_global_hashes)
-        .arg(&opencl.buffer_global_order)
-        .arg(&opencl.buffer_best_hashes)
-        .arg(&opencl.buffer_best_nonces)
-        .build()
-        .unwrap();
-
-    let mut kernel_event = EventList::new();
-    unsafe {
-        kernel.cmd().enew(&mut kernel_event).enq().expect("Unable to queue OpenCL kernel");
-    }
-
-    let mut hashes = vec![0u8; opencl.buffer_best_hashes.len()];
-    opencl.buffer_best_hashes
-        .read(&mut hashes)
-        .ewait(&kernel_event)
-        .enq()
-        .expect("Can't read buffer_best_hashes");
-
-    let mut nonces = vec![0u32; opencl.buffer_best_nonces.len()];
-    opencl.buffer_best_nonces
-        .read(&mut nonces)
-        .ewait(&kernel_event)
-        .enq()
-        .expect("Can't read buffer_best_nonces");
-
-    for i in 0..num_work_groups as usize {
-        let hash_bytes = &hashes[i * 32..(i * 32) + 32];
-        if hash_more_power(hash_bytes, &most_hash) {
-            most_hash.copy_from_slice(hash_bytes);
-            most_nonce = nonces[i];
-        }
-    }
-    
-    (most_nonce, most_hash)
-}

--- a/app/src/opencl_dia.rs
+++ b/app/src/opencl_dia.rs
@@ -1,0 +1,115 @@
+use x16rs::diamond_hash;
+
+fn do_diamond_group_mining_opencl(
+    opencl: &OpenCLResources,
+    number: u32,
+    prevblockhash: &Hash, 
+    rwdaddr: &Address,
+    custom_message: &Hash,
+    nonce_start: u64,
+    nonce_space: u64,
+    num_work_groups: u32,
+    local_work_size: u32,
+    unit_size: u32,
+) -> DiamondMiningResult {
+    let empthbytes = [0u8; 0];
+    let prevhash: &[u8; HASH_WIDTH] = prevblockhash;
+    let address: &[u8; 21] = rwdaddr;
+    let custom_nonce: &[u8] = match number > DIAMOND_ABOVE_NUMBER_OF_CREATE_BY_CUSTOM_MESSAGE {
+        true => custom_message.as_bytes(),
+        false => &empthbytes,
+    };
+    let mut most = DiamondMiningResult {
+        number,
+        nonce_start,
+        nonce_space,
+        u64_nonce: 0,
+        msg_nonce: custom_nonce.to_vec(),
+        dia_str: [b'W'; 16],
+        is_success: None,
+        use_secs: 0.0,
+    };
+    let global_work_size = num_work_groups * local_work_size;
+    let repeat = x16rs::mine_diamond_hash_repeat(number) as u32;
+    let stuff = [
+        prevhash.to_vec(),
+        [0u8; 8].to_vec(),
+        address.to_vec(),
+        custom_nonce.as_ref().to_vec(),
+    ].concat();
+
+    let buffer_block_intro = Buffer::<u8>::builder()
+        .queue(opencl.queue.clone())
+        .flags(ocl::core::MEM_READ_ONLY)
+        .len(stuff.len())
+        .copy_host_slice(&stuff)
+        .build()
+        .expect("Unable to create buffer_block_intro");
+
+    let kernel = Kernel::builder()
+        .program(&opencl.program)
+        .name("x16rs_diamond")
+        .queue(opencl.queue.clone())
+        .global_work_size(global_work_size)
+        .local_work_size(local_work_size)
+        .arg(&buffer_block_intro)
+        .arg(nonce_start)
+        .arg(repeat)
+        .arg(unit_size)
+        .arg(&opencl.buffer_global_hashes)
+        .arg(&opencl.buffer_global_order)
+        .arg(&opencl.buffer_best_hashes)
+        .arg(&opencl.buffer_best_nonces_diamond)
+        .build()
+        .unwrap();
+
+    let mut kernel_event = EventList::new();
+    unsafe {
+        kernel.cmd().enew(&mut kernel_event).enq().expect("Unable to queue OpenCL kernel");
+    }
+
+    let mut hashes = vec![0u8; opencl.buffer_best_hashes.len()];
+    opencl.buffer_best_hashes
+        .read(&mut hashes)
+        .ewait(&kernel_event)
+        .enq()
+        .expect("Can't read buffer_best_hashes");
+
+    let mut nonces = vec![0u64; opencl.buffer_best_nonces_diamond.len()];
+    opencl.buffer_best_nonces_diamond
+        .read(&mut nonces)
+        .ewait(&kernel_event)
+        .enq()
+        .expect("Can't read buffer_best_nonces_diamond");
+
+    for i in 0..num_work_groups as usize {
+        let hash_bytes = &hashes[i * 32..(i * 32) + 32].try_into().unwrap();
+        let dia_str = diamond_hash(&hash_bytes);
+        let nonce_bytes = nonces[i].to_be_bytes();
+        let stuff = [
+            prevblockhash.as_slice(),
+            nonce_bytes.as_slice(),
+            address.as_slice(),
+            custom_message.as_ref(),
+        ].concat();
+        let ssshash: [u8; 32] = calculate_hash(stuff);
+        
+        if let Some(dia_name) = check_diamer_success(number, ssshash, *hash_bytes, dia_str) {
+            let name = DiamondName::from(dia_name);
+            let number = DiamondNumber::from(number);
+            let mut diamint = DiamondMint::with(name, number);
+            diamint.d.prev_hash = prevblockhash.clone();
+            diamint.d.nonce = Fixed8::from(nonces[i].to_be_bytes());
+            diamint.d.address = rwdaddr.clone();
+            diamint.d.custom_message = custom_message.clone();
+            most.dia_str = dia_str;
+            most.u64_nonce = nonces[i];
+            most.is_success = Some(diamint);
+            return most;
+        } else if diamond_more_power(&dia_str, &most.dia_str) {
+            most.dia_str = dia_str;
+            most.u64_nonce = nonces[i];
+        }
+    }
+    most
+}

--- a/app/src/opencl_pow.rs
+++ b/app/src/opencl_pow.rs
@@ -1,0 +1,68 @@
+fn do_group_block_mining_opencl(
+    opencl: &OpenCLResources,
+    height: u64,
+    block_intro: Vec<u8>,
+    nonce_start: u32,
+    num_work_groups: u32,
+    local_work_size: u32,
+    unit_size: u32,
+) -> (u32, [u8; 32]) {
+    let mut most_nonce = 0u32;
+    let mut most_hash = [255u8; 32];
+    let global_work_size = num_work_groups * local_work_size;
+    let repeat = x16rs::block_hash_repeat(height) as u32;
+
+    let buffer_block_intro = Buffer::<u8>::builder()
+        .queue(opencl.queue.clone())
+        .flags(ocl::core::MEM_READ_ONLY)
+        .len(block_intro.len())
+        .copy_host_slice(&block_intro)
+        .build()
+        .expect("Unable to create buffer_block_intro");
+
+    let kernel = Kernel::builder()
+        .program(&opencl.program)
+        .name("x16rs_main")
+        .queue(opencl.queue.clone())
+        .global_work_size(global_work_size)
+        .local_work_size(local_work_size)
+        .arg(&buffer_block_intro)
+        .arg(nonce_start)
+        .arg(repeat)
+        .arg(unit_size)
+        .arg(&opencl.buffer_global_hashes)
+        .arg(&opencl.buffer_global_order)
+        .arg(&opencl.buffer_best_hashes)
+        .arg(&opencl.buffer_best_nonces)
+        .build()
+        .unwrap();
+
+    let mut kernel_event = EventList::new();
+    unsafe {
+        kernel.cmd().enew(&mut kernel_event).enq().expect("Unable to queue OpenCL kernel");
+    }
+
+    let mut hashes = vec![0u8; opencl.buffer_best_hashes.len()];
+    opencl.buffer_best_hashes
+        .read(&mut hashes)
+        .ewait(&kernel_event)
+        .enq()
+        .expect("Can't read buffer_best_hashes");
+
+    let mut nonces = vec![0u32; opencl.buffer_best_nonces.len()];
+    opencl.buffer_best_nonces
+        .read(&mut nonces)
+        .ewait(&kernel_event)
+        .enq()
+        .expect("Can't read buffer_best_nonces");
+
+    for i in 0..num_work_groups as usize {
+        let hash_bytes = &hashes[i * 32..(i * 32) + 32];
+        if hash_more_power(hash_bytes, &most_hash) {
+            most_hash.copy_from_slice(hash_bytes);
+            most_nonce = nonces[i];
+        }
+    }
+    
+    (most_nonce, most_hash)
+}

--- a/app/src/poworker.rs
+++ b/app/src/poworker.rs
@@ -144,7 +144,7 @@ pub fn poworker() {
     // Initialize OpenCL
     let opencl_resources: Vec<OpenCLResources> = if cnf.useopencl {
         #[cfg(feature = "ocl")]
-        { initialize_opencl(&cnf.clone()) }
+        { initialize_opencl(false, &cnf.opencldir, &cnf.platformid, &cnf.deviceids, &cnf.workgroups, &cnf.localsize, &cnf.unitsize) }
         #[cfg(not(feature = "ocl"))]
         Vec::new()
     } else {

--- a/app/src/poworker.rs
+++ b/app/src/poworker.rs
@@ -24,7 +24,9 @@ use mint::genesis::*;
 include!{"util.rs"}
 
 #[cfg(feature = "ocl")]
-include!{"opencl.rs"}
+include!{"opencl_common.rs"}
+#[cfg(feature = "ocl")]
+include!{"opencl_pow.rs"}
 
 
 
@@ -142,24 +144,27 @@ pub fn poworker() {
     let (res_tx, res_rx) = mpsc::channel();
 
     // Initialize OpenCL
+    #[cfg(feature = "ocl")]
     let opencl_resources: Vec<OpenCLResources> = if cnf.useopencl {
         #[cfg(feature = "ocl")]
         { initialize_opencl(false, &cnf.opencldir, &cnf.platformid, &cnf.deviceids, &cnf.workgroups, &cnf.localsize, &cnf.unitsize) }
-        #[cfg(not(feature = "ocl"))]
-        Vec::new()
     } else {
         // No OpenCL miners
         Vec::new()
     };
+    // Calculate device/cpu quantity
+    #[cfg(feature = "ocl")]
+    let vene: u32 = if cnf.useopencl { opencl_resources.len() as u32 } else { cnf.supervene };
+    #[cfg(not(feature = "ocl"))]
+    let vene: u32 = cnf.supervene;
 
     // deal results
     let cnf1 = cnf.clone();
-    let opencl_device_qty = opencl_resources.len();
     spawn(move || {
         let mut most_hash = vec![255u8; 32];
         let mut rstx = res_rx;
         loop {
-            deal_block_mining_results(&cnf1, &mut most_hash, &mut rstx, opencl_device_qty);
+            deal_block_mining_results(&cnf1, &mut most_hash, &mut rstx, vene);
             delay_continue_ms!(123);
         }
     });
@@ -175,7 +180,23 @@ pub fn poworker() {
                 let rstx: mpsc::Sender<Arc<BlockMiningResult>> = res_tx.clone();
                 spawn(move || {
                     loop {
-                        run_block_mining_item(&cnf2, thrid, rstx.clone(), Some(opencl_clone.clone()));
+                        run_block_mining_item_opencl(&cnf2, thrid, rstx.clone(), opencl_clone.clone());
+                        delay_continue_ms!(9);
+                    }
+                });
+            }
+        }
+        #[cfg(not(feature = "ocl"))]
+        {
+            println!("[Warning] use_opencl=true but app built without feature 'ocl'; fallback to CPU mining.");
+            let thrnum = cnf.supervene as usize;
+            println!("\n[Start] Create #{} block miner worker thread.", thrnum);
+            for thrid in 0 .. thrnum {
+                let cnf2 = cnf.clone();
+                let rstx = res_tx.clone();
+                spawn(move || {
+                    loop {
+                        run_block_mining_item(&cnf2, thrid, rstx.clone());
                         delay_continue_ms!(9);
                     }
                 });
@@ -190,7 +211,7 @@ pub fn poworker() {
             let rstx = res_tx.clone();
             spawn(move || {
                 loop {
-                    run_block_mining_item(&cnf2, thrid, rstx.clone(), None);
+                    run_block_mining_item(&cnf2, thrid, rstx.clone());
                     delay_continue_ms!(9);
                 }
             });
@@ -205,13 +226,8 @@ pub fn poworker() {
 }
 
 
-#[cfg(not(feature = "ocl"))]
-struct OpenCLResources {}
-
-
 fn run_block_mining_item(_cnf: &PoWorkConf, _thrid: usize,
     result_ch_tx: mpsc::Sender<Arc<BlockMiningResult>>,
-    _opencl: Option<Arc<OpenCLResources>>,
 ) {
 
     let mining_hei = MINING_BLOCK_HEIGHT.load(Relaxed);
@@ -222,11 +238,7 @@ fn run_block_mining_item(_cnf: &PoWorkConf, _thrid: usize,
     let mut coinbase_nonce = Hash::default();
     getrandom::fill(coinbase_nonce.as_mut()).unwrap();
     let mut nonce_start: u32 = 0;
-    let mut nonce_space: u32 = if !_cnf.useopencl {
-        100000
-    } else {
-        _cnf.workgroups * _cnf.localsize * _cnf.unitsize
-    };
+    let mut nonce_space: u32 = 100000;
     // stuff data
     let stuff = { MINING_BLOCK_STUFF.read().unwrap().clone() };
     let height = stuff.height;
@@ -239,26 +251,7 @@ fn run_block_mining_item(_cnf: &PoWorkConf, _thrid: usize,
     loop {
         let ctn = Instant::now();
 
-        #[cfg(not(feature = "ocl"))]
         let (head_nonce, result_hash) = do_group_block_mining(height, block_intro.serialize(), nonce_start, nonce_space);
-
-        #[cfg(feature = "ocl")]
-        let (head_nonce, result_hash) = if _cnf.useopencl {
-            let _opencl = _opencl
-                .as_ref()
-                .expect("OpenCL miner is disabled");
-            do_group_block_mining_opencl(
-                &_opencl,
-                height,
-                block_intro.serialize(),
-                nonce_start,
-                _cnf.workgroups,
-                _cnf.localsize,
-                _cnf.unitsize,
-            )
-        } else {
-            do_group_block_mining(height, block_intro.serialize(), nonce_start, nonce_space)
-        };
         
         let use_secs = Instant::now().duration_since(ctn).as_millis() as f64 / 1000.0;
         // record result
@@ -276,13 +269,78 @@ fn run_block_mining_item(_cnf: &PoWorkConf, _thrid: usize,
         if nonce_finish {
             return // end u32 nonce
         }
-        if !_cnf.useopencl { // nonce space is always the same in opencl
-            // update space
-            nonce_space = (nonce_space as f64 * MINING_INTERVAL / use_secs) as u32;
-        }
+        nonce_space = (nonce_space as f64 * MINING_INTERVAL / use_secs) as u32;
         let Some(nst) = nonce_start.checked_add(nonce_space) else {
             nonce_finish = true;
             nonce_space = u32::MAX - nonce_start - 1;
+            continue // // u32 nonce space finish
+        };
+        nonce_start = nst;
+        // check next height
+        let check_hei = MINING_BLOCK_HEIGHT.load(Relaxed);
+        if check_hei > mining_hei {
+            return // turn to next height
+        }
+        // continue nonce space
+    }
+
+}
+
+#[cfg(feature = "ocl")]
+fn run_block_mining_item_opencl(_cnf: &PoWorkConf, _thrid: usize,
+    result_ch_tx: mpsc::Sender<Arc<BlockMiningResult>>,
+    opencl: Arc<OpenCLResources>,
+) {
+
+    let mining_hei = MINING_BLOCK_HEIGHT.load(Relaxed);
+    if mining_hei == 0 {
+        delay_return_ms!(111); // not yet
+    }
+
+    let mut coinbase_nonce = Hash::default();
+    getrandom::fill(coinbase_nonce.as_mut()).unwrap();
+    let mut nonce_start: u32 = 0;
+    let nonce_space: u32 = _cnf.workgroups * _cnf.localsize * _cnf.unitsize;
+    // stuff data
+    let stuff = { MINING_BLOCK_STUFF.read().unwrap().clone() };
+    let height = stuff.height;
+    let mut cbtx = stuff.coinbase_tx.clone();
+    cbtx.set_nonce(coinbase_nonce);
+    let mut block_intro = stuff.block_intro.clone();
+    block_intro.set_mrklroot( calculate_mrkl_coinbase_update(cbtx.hash(), &stuff.mkrl_list) );
+    // nonce total space = u32
+    let mut nonce_finish = false;
+    loop {
+        let ctn = Instant::now();
+
+        let (head_nonce, result_hash) = do_group_block_mining_opencl(
+            &opencl,
+            height,
+            block_intro.serialize(),
+            nonce_start,
+            _cnf.workgroups,
+            _cnf.localsize,
+            _cnf.unitsize,
+        );
+        
+        let use_secs = Instant::now().duration_since(ctn).as_millis() as f64 / 1000.0;
+        // record result
+        let mlres = BlockMiningResult {
+            height,
+            nonce_start,
+            nonce_space,
+            head_nonce,
+            coinbase_nonce: coinbase_nonce.to_vec(),
+            result_hash: result_hash.to_vec(),
+            target_hash: stuff.target_hash.to_vec(),
+            use_secs,
+        };
+        result_ch_tx.send(mlres.into()).unwrap();
+        if nonce_finish {
+            return // end u32 nonce
+        }
+        let Some(nst) = nonce_start.checked_add(nonce_space) else {
+            nonce_finish = true;
             continue // // u32 nonce space finish
         };
         nonce_start = nst;
@@ -317,13 +375,8 @@ fn do_group_block_mining(height: u64, mut block_intro: Vec<u8>,
 
 fn deal_block_mining_results(cnf: &PoWorkConf, most_hash: &mut Vec<u8>,
     result_ch_rx: &mut mpsc::Receiver<Arc<BlockMiningResult>>,
-    opencl_device_qty: usize
+    vene: u32
 ) {
-    let vene = if cnf.useopencl {
-        opencl_device_qty as u32
-    } else {
-        cnf.supervene
-    };
     // deal
     let mut deal_hei = 0u64;
     let mut most = Arc::new(BlockMiningResult::new());

--- a/x16rs/opencl/sha3_256.cl
+++ b/x16rs/opencl/sha3_256.cl
@@ -175,4 +175,32 @@ inline void sha3_256_hash(const ulong *input, ulong *output)
 	output[3] = hash[3];
 }
 
+inline void sha3_256_hash_diamond(const ulong *input, ulong *output)
+{	
+	ulong ALIGN hash[25] = {
+		le2me_64(input[ 0]),
+		le2me_64(input[ 1]),
+		le2me_64(input[ 2]),
+		le2me_64(input[ 3]),
+		le2me_64(input[ 4]),
+		le2me_64(input[ 5]),
+		le2me_64(input[ 6]),
+		le2me_64(input[ 7]),
+		le2me_64(input[ 8]),
+		le2me_64(input[ 9]),
+		le2me_64(input[10]),
+		(le2me_64(input[11]) & (ulong)0x000000FFFFFFFFFFUL) | (ulong)0x0000060000000000UL,
+		0,
+		0,
+		0,
+		0,
+		le2me_64(0x8000000000000000),
+	};
+	rhash_sha3_permutation(hash);
+	output[0] = hash[0];
+	output[1] = hash[1];
+	output[2] = hash[2];
+	output[3] = hash[3];
+}
+
 #endif  // SHA3_256_CL

--- a/x16rs/opencl/util.cl
+++ b/x16rs/opencl/util.cl
@@ -11,6 +11,11 @@ typedef union ALIGN8 {
   ulong h8[11];
 } block_t;
 
+typedef union ALIGN8 {
+  unsigned char h1[96];
+  ulong h8[12];
+} block_diamond_t;
+
 #ifdef __ENDIAN_LITTLE__
 
     #define WRITE_NONCE_BYTE4 bytes[offset+0] = nonce_ptr[3]; \
@@ -31,6 +36,17 @@ __inline__ void write_nonce_to_bytes(const int offset, unsigned char* bytes, uns
     // nonce bytes
     unsigned char *nonce_ptr = (unsigned char *)&nonce;
     WRITE_NONCE_BYTE4;
+}
+
+__inline__ void write_nonce_u64_to_bytes(const int offset, unsigned char* bytes, ulong nonce) {
+    bytes[offset + 0] = (uchar)(nonce >> 56);
+    bytes[offset + 1] = (uchar)(nonce >> 48);
+    bytes[offset + 2] = (uchar)(nonce >> 40);
+    bytes[offset + 3] = (uchar)(nonce >> 32);
+    bytes[offset + 4] = (uchar)(nonce >> 24);
+    bytes[offset + 5] = (uchar)(nonce >> 16);
+    bytes[offset + 6] = (uchar)(nonce >> 8);
+    bytes[offset + 7] = (uchar)(nonce);
 }
 
 #endif

--- a/x16rs/opencl/x16rs.cl
+++ b/x16rs/opencl/x16rs.cl
@@ -99,6 +99,10 @@ typedef union ALIGN {
   ulong h8[4];
 } hash_32;
 
+typedef union ALIGN {
+  unsigned char h1[16];
+} diamond_t;
+
 // blake
 void hash_x16rs_func_0(hash_32* hash, __constant sph_u64* H_blake)
 {

--- a/x16rs/opencl/x16rs.cl
+++ b/x16rs/opencl/x16rs.cl
@@ -103,6 +103,125 @@ typedef union ALIGN {
   unsigned char h1[16];
 } diamond_t;
 
+#define X16RS_DECLARE_H_BLAKE() \
+    __constant sph_u64 ALIGN H_blake[8] = { \
+        SPH_C64(0x6A09E667F3BCC908), SPH_C64(0xBB67AE8584CAA73B), \
+        SPH_C64(0x3C6EF372FE94F82B), SPH_C64(0xA54FF53A5F1D36F1), \
+        SPH_C64(0x510E527FADE682D1), SPH_C64(0x9B05688C2B3E6C1F), \
+        SPH_C64(0x1F83D9ABFB41BD6B), SPH_C64(0x5BE0CD19137E2179) \
+    }
+
+#define X16RS_INIT_SHARED_TABLES(local_id, local_size) \
+    X16RS_DECLARE_H_BLAKE(); \
+    __local ulong ALIGN8 T0[256], T1[256], T2[256], T3[256]; \
+    __local sph_u32 ALIGN32 AES0[256], AES1[256], AES2[256], AES3[256]; \
+    __local sph_u64 ALIGN64 LT0[256], LT1[256], LT2[256], LT3[256], LT4[256], LT5[256], LT6[256], LT7[256]; \
+    __local sph_u32 ALIGN64 mixtab0[256], mixtab1[256], mixtab2[256], mixtab3[256]; \
+    for (unsigned i = (local_id); i < 256; i += (local_size)) { \
+        T0[i] = T0_G[i]; \
+        T1[i] = rotate(T0[i], 8UL); \
+        T2[i] = rotate(T0[i], 16UL); \
+        T3[i] = rotate(T0[i], 24UL); \
+        AES0[i] = AES0_C[i]; \
+        AES1[i] = rotate(AES0[i], 8U); \
+        AES2[i] = rotate(AES0[i], 16U); \
+        AES3[i] = rotate(AES0[i], 24U); \
+        LT0[i] = plain_T0[i]; \
+        LT1[i] = plain_T1[i]; \
+        LT2[i] = plain_T2[i]; \
+        LT3[i] = plain_T3[i]; \
+        LT4[i] = plain_T4[i]; \
+        LT5[i] = plain_T5[i]; \
+        LT6[i] = plain_T6[i]; \
+        LT7[i] = plain_T7[i]; \
+        mixtab0[i] = mixtab0_c[i]; \
+        mixtab1[i] = mixtab1_c[i]; \
+        mixtab2[i] = mixtab2_c[i]; \
+        mixtab3[i] = mixtab3_c[i]; \
+    } \
+    barrier(CLK_LOCAL_MEM_FENCE)
+
+#define X16RS_RUN_REPEAT_LOOP(local_id, local_size, unit_size, x16rs_repeat, local_hashes, index, local_order, histogram, starting_index, offset, H_blake, T0, T1, T2, T3, AES0, AES1, AES2, AES3, LT0, LT1, LT2, LT3, LT4, LT5, LT6, LT7, mixtab0, mixtab1, mixtab2, mixtab3) \
+    for (unsigned char r = 0; r < (x16rs_repeat); r++) { \
+        if ((local_id) < 16) { \
+            (histogram)[(local_id)] = 0; \
+            (offset)[(local_id)] = 0; \
+        } \
+        barrier(CLK_LOCAL_MEM_FENCE); \
+        for (unsigned int h = 0; h < (unit_size); h++) { \
+            unsigned char mod = (local_hashes)[(index) + h].h4[7] % 16; \
+            atomic_inc(&(histogram)[mod]); \
+        } \
+        barrier(CLK_LOCAL_MEM_FENCE); \
+        if ((local_id) == 0) { \
+            (starting_index)[0] = 0; \
+            for (unsigned char i = 1; i < 16; i++) { \
+                (starting_index)[i] = (starting_index)[i - 1] + (histogram)[i - 1]; \
+            } \
+        } \
+        barrier(CLK_LOCAL_MEM_FENCE); \
+        for (unsigned int h = 0; h < (unit_size); h++) { \
+            unsigned int mod = (local_hashes)[(index) + h].h4[7] % 16; \
+            unsigned int pos = (starting_index)[mod] + atomic_inc(&(offset)[mod]); \
+            (local_order)[pos] = (index) + h; \
+        } \
+        barrier(CLK_LOCAL_MEM_FENCE); \
+        for (unsigned int h = 0; h < (unit_size); h++) { \
+            const unsigned int* hash_pos = &(local_order)[((local_size) * h) + (local_id)]; \
+            switch ((local_hashes)[hash_pos[0]].h4[7] % 16) { \
+                case 0: \
+                    hash_x16rs_func_0(&(local_hashes)[hash_pos[0]], (H_blake)); \
+                    break; \
+                case 1: \
+                    hash_x16rs_func_1(&(local_hashes)[hash_pos[0]]); \
+                    break; \
+                case 2: \
+                    hash_x16rs_func_2(&(local_hashes)[hash_pos[0]], (T0), (T1), (T2), (T3)); \
+                    break; \
+                case 3: \
+                    hash_x16rs_func_3(&(local_hashes)[hash_pos[0]]); \
+                    break; \
+                case 4: \
+                    hash_x16rs_func_4(&(local_hashes)[hash_pos[0]]); \
+                    break; \
+                case 5: \
+                    hash_x16rs_func_5(&(local_hashes)[hash_pos[0]]); \
+                    break; \
+                case 6: \
+                    hash_x16rs_func_6(&(local_hashes)[hash_pos[0]]); \
+                    break; \
+                case 7: \
+                    hash_x16rs_func_7(&(local_hashes)[hash_pos[0]]); \
+                    break; \
+                case 8: \
+                    hash_x16rs_func_8(&(local_hashes)[hash_pos[0]], (AES0), (AES1), (AES2), (AES3)); \
+                    break; \
+                case 9: \
+                    hash_x16rs_func_9(&(local_hashes)[hash_pos[0]]); \
+                    break; \
+                case 10: \
+                    hash_x16rs_func_10(&(local_hashes)[hash_pos[0]], (AES0), (AES1), (AES2), (AES3)); \
+                    break; \
+                case 11: \
+                    hash_x16rs_func_11(&(local_hashes)[hash_pos[0]]); \
+                    break; \
+                case 12: \
+                    hash_x16rs_func_12(&(local_hashes)[hash_pos[0]], (mixtab0), (mixtab1), (mixtab2), (mixtab3)); \
+                    break; \
+                case 13: \
+                    hash_x16rs_func_13(&(local_hashes)[hash_pos[0]]); \
+                    break; \
+                case 14: \
+                    hash_x16rs_func_14(&(local_hashes)[hash_pos[0]], (LT0), (LT1), (LT2), (LT3), (LT4), (LT5), (LT6), (LT7)); \
+                    break; \
+                case 15: \
+                    hash_x16rs_func_15(&(local_hashes)[hash_pos[0]]); \
+                    break; \
+            } \
+            barrier(CLK_LOCAL_MEM_FENCE); \
+        } \
+    }
+
 // blake
 void hash_x16rs_func_0(hash_32* hash, __constant sph_u64* H_blake)
 {

--- a/x16rs/opencl/x16rs_diamond.cl
+++ b/x16rs/opencl/x16rs_diamond.cl
@@ -1,0 +1,260 @@
+#include "util.cl"
+#include "x16rs.cl"
+#include "sha3_256.cl"
+
+// Diamond name calculation constants
+#define DMD_M 16
+#define H32S 32
+#define DIAMOND_HASH_BASE_CHAR_NUM 17
+__constant uchar DIAMOND_HASH_BASE_CHARS[DIAMOND_HASH_BASE_CHAR_NUM] = "0WTYUIAHXVMEKBSZN";
+
+inline int diff_big_hash(const hash_32 *src, const hash_32 *tar)
+{
+    #pragma unroll 32
+    for (int i = 0; i < 32; i++) {
+        if (src->h1[i] > tar->h1[i]) {
+            return 1;
+        } else if (src->h1[i] < tar->h1[i]) {
+            return 0;
+        }
+    }
+    return 0;
+}
+
+inline void diamond_hash(const uchar *bshash, uchar *reshx)
+{
+    uint mgcidx = 13u;
+    for (uint i = 0u; i < (uint)DMD_M; i++) {
+        uint a = (uint)bshash[i * 2u];
+        uint b = (uint)bshash[i * 2u + 1u];
+        uint num = mgcidx * a * b;
+        mgcidx = num % (uint)DIAMOND_HASH_BASE_CHAR_NUM;
+        reshx[i] = DIAMOND_HASH_BASE_CHARS[mgcidx];
+        if (mgcidx == 0u) mgcidx = 13u;
+    }
+}
+
+inline bool diamond_more_power(const uchar *dst,
+                                 const uchar *src)
+{
+     const uchar o = (uchar)'0';
+    for (uint i = 0u; i < 16u; i++) {
+        uchar l = dst[i];
+        uchar r = src[i];
+        if (l == o && r != o) return 1;
+        if (l != o && r == o) return 0;
+        if (l != o && r != o) return 0;
+    }
+    return 0;
+}
+
+__attribute__((work_group_size_hint(256, 1, 1)))
+__kernel void x16rs_diamond(
+    __constant const block_diamond_t* input_stuff,
+    const ulong nonce_start,
+    const unsigned int x16rs_repeat,
+    const unsigned int unit_size,
+    __global hash_32* global_hashes,
+    __global unsigned int* global_order,
+    __global hash_32* best_hashes,
+    __global ulong* best_nonces
+) {
+    const unsigned int local_id = get_local_id(0);
+    const unsigned int local_size = get_local_size(0);
+    const unsigned int group_id = get_group_id(0);
+    const unsigned int index = local_id * unit_size;
+    hash_32* local_hashes = global_hashes + (group_id * local_size * unit_size);
+    __local ulong local_nonces[256];
+    __local diamond_t local_names[256];
+    __global unsigned int* local_order = global_order + (group_id * local_size * unit_size);
+    __local unsigned int ALIGN histogram[16];
+    __local unsigned int ALIGN starting_index[16];
+    __local unsigned int ALIGN offset[16];
+
+    // Setup x16 local shared vars
+    __constant sph_u64 ALIGN H_blake[8] = {
+        SPH_C64(0x6A09E667F3BCC908), SPH_C64(0xBB67AE8584CAA73B),
+        SPH_C64(0x3C6EF372FE94F82B), SPH_C64(0xA54FF53A5F1D36F1),
+        SPH_C64(0x510E527FADE682D1), SPH_C64(0x9B05688C2B3E6C1F),
+        SPH_C64(0x1F83D9ABFB41BD6B), SPH_C64(0x5BE0CD19137E2179)
+    };
+    
+    __local ulong ALIGN8 T0[256], T1[256], T2[256], T3[256];
+    __local sph_u32 ALIGN32 AES0[256], AES1[256], AES2[256], AES3[256];
+    __local sph_u64 ALIGN64 LT0[256], LT1[256], LT2[256], LT3[256], LT4[256], LT5[256], LT6[256], LT7[256];
+    __local sph_u32 ALIGN64 mixtab0[256], mixtab1[256], mixtab2[256], mixtab3[256];
+    for (unsigned i = local_id; i < 256; i += local_size) {
+        T0[i] = T0_G[i];
+        T1[i] = rotate(T0[i], 8UL);
+        T2[i] = rotate(T0[i], 16UL);
+        T3[i] = rotate(T0[i], 24UL);
+        
+        AES0[i] = AES0_C[i];
+        AES1[i] = rotate(AES0[i], 8U);
+        AES2[i] = rotate(AES0[i], 16U);
+        AES3[i] = rotate(AES0[i], 24U);
+
+        LT0[i] = plain_T0[i];
+        LT1[i] = plain_T1[i];
+        LT2[i] = plain_T2[i];
+        LT3[i] = plain_T3[i];
+        LT4[i] = plain_T4[i];
+        LT5[i] = plain_T5[i];
+        LT6[i] = plain_T6[i];
+        LT7[i] = plain_T7[i];
+
+        mixtab0[i] = mixtab0_c[i];
+        mixtab1[i] = mixtab1_c[i];
+        mixtab2[i] = mixtab2_c[i];
+        mixtab3[i] = mixtab3_c[i];
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    block_diamond_t base_stuff = input_stuff[0];
+    
+    const ulong global_offset = nonce_start + (get_global_id(0) * unit_size);
+    for (unsigned int i = 0; i < unit_size; i++) {
+        volatile const ulong nonce = global_offset + i;
+        if(false) {
+            // Insert Nonce
+            write_nonce_to_bytes(79, base_stuff.h1, nonce);
+        } else {
+            write_nonce_u64_to_bytes(32, base_stuff.h1, nonce);
+        }
+        // Hash Block
+        sha3_256_hash_diamond(base_stuff.h8, local_hashes[index + i].h8);
+    }          
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (unsigned char r = 0; r < x16rs_repeat; r++) {
+
+        // Reset sorting indices
+        if (local_id < 16) {
+            histogram[local_id] = 0;
+            offset[local_id] = 0;
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        // Sumarize by algo
+        for (unsigned int h = 0; h < unit_size; h++) {
+            unsigned char mod = local_hashes[index + h].h4[7] % 16;
+            atomic_inc(&histogram[mod]);
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        // Calculate start index
+        if (local_id == 0) {
+            starting_index[0] = 0;
+            #pragma unroll 15
+            for (unsigned char i = 1; i < 16; i++) {
+                starting_index[i] = starting_index[i - 1] + histogram[i - 1];
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        // Save each hash position
+        for (unsigned int h = 0; h < unit_size; h++) {
+            unsigned int mod = local_hashes[index + h].h4[7] % 16;
+            unsigned int pos = starting_index[mod] + atomic_inc(&offset[mod]);
+            local_order[pos] = index + h;
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for(unsigned int h = 0; h < unit_size; h++) {
+            const unsigned int* hash_pos = &local_order[(local_size * h) + local_id];
+            switch(local_hashes[hash_pos[0]].h4[7] % 16) {
+                case 0:
+                    hash_x16rs_func_0(&local_hashes[hash_pos[0]], H_blake);
+                    break;
+                case 1:
+                    hash_x16rs_func_1(&local_hashes[hash_pos[0]]);
+                    break;
+                case 2:
+                    hash_x16rs_func_2(&local_hashes[hash_pos[0]], T0, T1, T2, T3);
+                    break;
+                case 3:
+                    hash_x16rs_func_3(&local_hashes[hash_pos[0]]);
+                    break;
+                case 4:
+                    hash_x16rs_func_4(&local_hashes[hash_pos[0]]);
+                    break;
+                case 5:
+                    hash_x16rs_func_5(&local_hashes[hash_pos[0]]);
+                    break;
+                case 6:
+                    hash_x16rs_func_6(&local_hashes[hash_pos[0]]);
+                    break;
+                case 7:
+                    hash_x16rs_func_7(&local_hashes[hash_pos[0]]);
+                    break;
+                case 8:
+                    hash_x16rs_func_8(&local_hashes[hash_pos[0]], AES0, AES1, AES2, AES3);
+                    break;
+                case 9:
+                    hash_x16rs_func_9(&local_hashes[hash_pos[0]]);
+                    break;
+                case 10:
+                    hash_x16rs_func_10(&local_hashes[hash_pos[0]], AES0, AES1, AES2, AES3);
+                    break;
+                case 11:
+                    hash_x16rs_func_11(&local_hashes[hash_pos[0]]);
+                    break;
+                case 12:
+                    hash_x16rs_func_12(&local_hashes[hash_pos[0]], mixtab0, mixtab1, mixtab2, mixtab3);
+                    break;
+                case 13:
+                    hash_x16rs_func_13(&local_hashes[hash_pos[0]]);
+                    break;
+                case 14:
+                    hash_x16rs_func_14(&local_hashes[hash_pos[0]], LT0, LT1, LT2, LT3, LT4, LT5, LT6, LT7);
+                    break;
+                case 15:
+                    hash_x16rs_func_15(&local_hashes[hash_pos[0]]);
+                    break;
+            }
+            barrier(CLK_LOCAL_MEM_FENCE);
+        }
+    }
+    
+    unsigned int best_hash = 0;
+    diamond_t best_name;
+    for (unsigned int i = 1; i < unit_size; i++) {
+        // Get diamond name
+        diamond_t now_name;
+        diamond_hash(local_hashes[index + i].h1, now_name.h1);
+        if (diamond_more_power(now_name.h1, best_name.h1) == 1) {
+            best_hash = index + i;
+            best_name = now_name;
+        }
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    local_hashes[index] = local_hashes[best_hash];
+    local_nonces[local_id] = global_offset + best_hash - index;
+    
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    // Now perform the reduction across threads
+    for (unsigned int smax = local_size >> 1; smax > 0; smax >>= 1) {
+        if (local_id < smax) {
+            unsigned int idx_current = index;
+            unsigned int idx_pair = (local_id + smax) * unit_size;
+            diamond_t current_name;
+            diamond_t pair_name;
+            diamond_hash(local_hashes[idx_current].h1, current_name.h1);
+            diamond_hash(local_hashes[idx_pair].h1, pair_name.h1);
+            if (diamond_more_power(pair_name.h1, current_name.h1) == 1) {
+                local_hashes[idx_current] = local_hashes[idx_pair];
+                local_nonces[local_id] = local_nonces[local_id + smax];
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if(local_id == 0) {
+        best_nonces[group_id] = local_nonces[0];
+    }
+    if(local_id < 32) {
+        best_hashes[group_id].h1[local_id] = local_hashes[0].h1[local_id];
+    }
+}

--- a/x16rs/opencl/x16rs_diamond.cl
+++ b/x16rs/opencl/x16rs_diamond.cl
@@ -72,43 +72,7 @@ __kernel void x16rs_diamond(
     __local unsigned int ALIGN offset[16];
 
     // Setup x16 local shared vars
-    __constant sph_u64 ALIGN H_blake[8] = {
-        SPH_C64(0x6A09E667F3BCC908), SPH_C64(0xBB67AE8584CAA73B),
-        SPH_C64(0x3C6EF372FE94F82B), SPH_C64(0xA54FF53A5F1D36F1),
-        SPH_C64(0x510E527FADE682D1), SPH_C64(0x9B05688C2B3E6C1F),
-        SPH_C64(0x1F83D9ABFB41BD6B), SPH_C64(0x5BE0CD19137E2179)
-    };
-    
-    __local ulong ALIGN8 T0[256], T1[256], T2[256], T3[256];
-    __local sph_u32 ALIGN32 AES0[256], AES1[256], AES2[256], AES3[256];
-    __local sph_u64 ALIGN64 LT0[256], LT1[256], LT2[256], LT3[256], LT4[256], LT5[256], LT6[256], LT7[256];
-    __local sph_u32 ALIGN64 mixtab0[256], mixtab1[256], mixtab2[256], mixtab3[256];
-    for (unsigned i = local_id; i < 256; i += local_size) {
-        T0[i] = T0_G[i];
-        T1[i] = rotate(T0[i], 8UL);
-        T2[i] = rotate(T0[i], 16UL);
-        T3[i] = rotate(T0[i], 24UL);
-        
-        AES0[i] = AES0_C[i];
-        AES1[i] = rotate(AES0[i], 8U);
-        AES2[i] = rotate(AES0[i], 16U);
-        AES3[i] = rotate(AES0[i], 24U);
-
-        LT0[i] = plain_T0[i];
-        LT1[i] = plain_T1[i];
-        LT2[i] = plain_T2[i];
-        LT3[i] = plain_T3[i];
-        LT4[i] = plain_T4[i];
-        LT5[i] = plain_T5[i];
-        LT6[i] = plain_T6[i];
-        LT7[i] = plain_T7[i];
-
-        mixtab0[i] = mixtab0_c[i];
-        mixtab1[i] = mixtab1_c[i];
-        mixtab2[i] = mixtab2_c[i];
-        mixtab3[i] = mixtab3_c[i];
-    }
-    barrier(CLK_LOCAL_MEM_FENCE);
+    X16RS_INIT_SHARED_TABLES(local_id, local_size);
 
     block_diamond_t base_stuff = input_stuff[0];
     
@@ -126,95 +90,16 @@ __kernel void x16rs_diamond(
     }          
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    for (unsigned char r = 0; r < x16rs_repeat; r++) {
-
-        // Reset sorting indices
-        if (local_id < 16) {
-            histogram[local_id] = 0;
-            offset[local_id] = 0;
-        }
-        barrier(CLK_LOCAL_MEM_FENCE);
-
-        // Sumarize by algo
-        for (unsigned int h = 0; h < unit_size; h++) {
-            unsigned char mod = local_hashes[index + h].h4[7] % 16;
-            atomic_inc(&histogram[mod]);
-        }
-        barrier(CLK_LOCAL_MEM_FENCE);
-
-        // Calculate start index
-        if (local_id == 0) {
-            starting_index[0] = 0;
-            #pragma unroll 15
-            for (unsigned char i = 1; i < 16; i++) {
-                starting_index[i] = starting_index[i - 1] + histogram[i - 1];
-            }
-        }
-        barrier(CLK_LOCAL_MEM_FENCE);
-
-        // Save each hash position
-        for (unsigned int h = 0; h < unit_size; h++) {
-            unsigned int mod = local_hashes[index + h].h4[7] % 16;
-            unsigned int pos = starting_index[mod] + atomic_inc(&offset[mod]);
-            local_order[pos] = index + h;
-        }
-        barrier(CLK_LOCAL_MEM_FENCE);
-
-        for(unsigned int h = 0; h < unit_size; h++) {
-            const unsigned int* hash_pos = &local_order[(local_size * h) + local_id];
-            switch(local_hashes[hash_pos[0]].h4[7] % 16) {
-                case 0:
-                    hash_x16rs_func_0(&local_hashes[hash_pos[0]], H_blake);
-                    break;
-                case 1:
-                    hash_x16rs_func_1(&local_hashes[hash_pos[0]]);
-                    break;
-                case 2:
-                    hash_x16rs_func_2(&local_hashes[hash_pos[0]], T0, T1, T2, T3);
-                    break;
-                case 3:
-                    hash_x16rs_func_3(&local_hashes[hash_pos[0]]);
-                    break;
-                case 4:
-                    hash_x16rs_func_4(&local_hashes[hash_pos[0]]);
-                    break;
-                case 5:
-                    hash_x16rs_func_5(&local_hashes[hash_pos[0]]);
-                    break;
-                case 6:
-                    hash_x16rs_func_6(&local_hashes[hash_pos[0]]);
-                    break;
-                case 7:
-                    hash_x16rs_func_7(&local_hashes[hash_pos[0]]);
-                    break;
-                case 8:
-                    hash_x16rs_func_8(&local_hashes[hash_pos[0]], AES0, AES1, AES2, AES3);
-                    break;
-                case 9:
-                    hash_x16rs_func_9(&local_hashes[hash_pos[0]]);
-                    break;
-                case 10:
-                    hash_x16rs_func_10(&local_hashes[hash_pos[0]], AES0, AES1, AES2, AES3);
-                    break;
-                case 11:
-                    hash_x16rs_func_11(&local_hashes[hash_pos[0]]);
-                    break;
-                case 12:
-                    hash_x16rs_func_12(&local_hashes[hash_pos[0]], mixtab0, mixtab1, mixtab2, mixtab3);
-                    break;
-                case 13:
-                    hash_x16rs_func_13(&local_hashes[hash_pos[0]]);
-                    break;
-                case 14:
-                    hash_x16rs_func_14(&local_hashes[hash_pos[0]], LT0, LT1, LT2, LT3, LT4, LT5, LT6, LT7);
-                    break;
-                case 15:
-                    hash_x16rs_func_15(&local_hashes[hash_pos[0]]);
-                    break;
-            }
-            barrier(CLK_LOCAL_MEM_FENCE);
-        }
-    }
+    X16RS_RUN_REPEAT_LOOP(
+        local_id, local_size, unit_size, x16rs_repeat,
+        local_hashes, index, local_order,
+        histogram, starting_index, offset,
+        H_blake,
+        T0, T1, T2, T3,
+        AES0, AES1, AES2, AES3,
+        LT0, LT1, LT2, LT3, LT4, LT5, LT6, LT7,
+        mixtab0, mixtab1, mixtab2, mixtab3
+    );
     
     unsigned int best_hash = 0;
     diamond_t best_name;

--- a/x16rs/opencl/x16rs_main.cl
+++ b/x16rs/opencl/x16rs_main.cl
@@ -38,43 +38,7 @@ __kernel void x16rs_main(
     __local unsigned int ALIGN offset[16];
 
     // Setup x16 local shared vars
-    __constant sph_u64 ALIGN H_blake[8] = {
-        SPH_C64(0x6A09E667F3BCC908), SPH_C64(0xBB67AE8584CAA73B),
-        SPH_C64(0x3C6EF372FE94F82B), SPH_C64(0xA54FF53A5F1D36F1),
-        SPH_C64(0x510E527FADE682D1), SPH_C64(0x9B05688C2B3E6C1F),
-        SPH_C64(0x1F83D9ABFB41BD6B), SPH_C64(0x5BE0CD19137E2179)
-    };
-    
-    __local ulong ALIGN8 T0[256], T1[256], T2[256], T3[256];
-    __local sph_u32 ALIGN32 AES0[256], AES1[256], AES2[256], AES3[256];
-    __local sph_u64 ALIGN64 LT0[256], LT1[256], LT2[256], LT3[256], LT4[256], LT5[256], LT6[256], LT7[256];
-    __local sph_u32 ALIGN64 mixtab0[256], mixtab1[256], mixtab2[256], mixtab3[256];
-    for (unsigned i = local_id; i < 256; i += local_size) {
-        T0[i] = T0_G[i];
-        T1[i] = rotate(T0[i], 8UL);
-        T2[i] = rotate(T0[i], 16UL);
-        T3[i] = rotate(T0[i], 24UL);
-        
-        AES0[i] = AES0_C[i];
-        AES1[i] = rotate(AES0[i], 8U);
-        AES2[i] = rotate(AES0[i], 16U);
-        AES3[i] = rotate(AES0[i], 24U);
-
-        LT0[i] = plain_T0[i];
-        LT1[i] = plain_T1[i];
-        LT2[i] = plain_T2[i];
-        LT3[i] = plain_T3[i];
-        LT4[i] = plain_T4[i];
-        LT5[i] = plain_T5[i];
-        LT6[i] = plain_T6[i];
-        LT7[i] = plain_T7[i];
-
-        mixtab0[i] = mixtab0_c[i];
-        mixtab1[i] = mixtab1_c[i];
-        mixtab2[i] = mixtab2_c[i];
-        mixtab3[i] = mixtab3_c[i];
-    }
-    barrier(CLK_LOCAL_MEM_FENCE);
+    X16RS_INIT_SHARED_TABLES(local_id, local_size);
 
     block_t base_stuff = input_stuff_89[0];
     
@@ -88,95 +52,16 @@ __kernel void x16rs_main(
     }          
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    for (unsigned char r = 0; r < x16rs_repeat; r++) {
-
-        // Reset sorting indices
-        if (local_id < 16) {
-            histogram[local_id] = 0;
-            offset[local_id] = 0;
-        }
-        barrier(CLK_LOCAL_MEM_FENCE);
-
-        // Sumarize by algo
-        for (unsigned int h = 0; h < unit_size; h++) {
-            unsigned char mod = local_hashes[index + h].h4[7] % 16;
-            atomic_inc(&histogram[mod]);
-        }
-        barrier(CLK_LOCAL_MEM_FENCE);
-
-        // Calculate start index
-        if (local_id == 0) {
-            starting_index[0] = 0;
-            #pragma unroll 15
-            for (unsigned char i = 1; i < 16; i++) {
-                starting_index[i] = starting_index[i - 1] + histogram[i - 1];
-            }
-        }
-        barrier(CLK_LOCAL_MEM_FENCE);
-
-        // Save each hash position
-        for (unsigned int h = 0; h < unit_size; h++) {
-            unsigned int mod = local_hashes[index + h].h4[7] % 16;
-            unsigned int pos = starting_index[mod] + atomic_inc(&offset[mod]);
-            local_order[pos] = index + h;
-        }
-        barrier(CLK_LOCAL_MEM_FENCE);
-
-        for(unsigned int h = 0; h < unit_size; h++) {
-            const unsigned int* hash_pos = &local_order[(local_size * h) + local_id];
-            switch(local_hashes[hash_pos[0]].h4[7] % 16) {
-                case 0:
-                    hash_x16rs_func_0(&local_hashes[hash_pos[0]], H_blake);
-                    break;
-                case 1:
-                    hash_x16rs_func_1(&local_hashes[hash_pos[0]]);
-                    break;
-                case 2:
-                    hash_x16rs_func_2(&local_hashes[hash_pos[0]], T0, T1, T2, T3);
-                    break;
-                case 3:
-                    hash_x16rs_func_3(&local_hashes[hash_pos[0]]);
-                    break;
-                case 4:
-                    hash_x16rs_func_4(&local_hashes[hash_pos[0]]);
-                    break;
-                case 5:
-                    hash_x16rs_func_5(&local_hashes[hash_pos[0]]);
-                    break;
-                case 6:
-                    hash_x16rs_func_6(&local_hashes[hash_pos[0]]);
-                    break;
-                case 7:
-                    hash_x16rs_func_7(&local_hashes[hash_pos[0]]);
-                    break;
-                case 8:
-                    hash_x16rs_func_8(&local_hashes[hash_pos[0]], AES0, AES1, AES2, AES3);
-                    break;
-                case 9:
-                    hash_x16rs_func_9(&local_hashes[hash_pos[0]]);
-                    break;
-                case 10:
-                    hash_x16rs_func_10(&local_hashes[hash_pos[0]], AES0, AES1, AES2, AES3);
-                    break;
-                case 11:
-                    hash_x16rs_func_11(&local_hashes[hash_pos[0]]);
-                    break;
-                case 12:
-                    hash_x16rs_func_12(&local_hashes[hash_pos[0]], mixtab0, mixtab1, mixtab2, mixtab3);
-                    break;
-                case 13:
-                    hash_x16rs_func_13(&local_hashes[hash_pos[0]]);
-                    break;
-                case 14:
-                    hash_x16rs_func_14(&local_hashes[hash_pos[0]], LT0, LT1, LT2, LT3, LT4, LT5, LT6, LT7);
-                    break;
-                case 15:
-                    hash_x16rs_func_15(&local_hashes[hash_pos[0]]);
-                    break;
-            }
-            barrier(CLK_LOCAL_MEM_FENCE);
-        }
-    }
+    X16RS_RUN_REPEAT_LOOP(
+        local_id, local_size, unit_size, x16rs_repeat,
+        local_hashes, index, local_order,
+        histogram, starting_index, offset,
+        H_blake,
+        T0, T1, T2, T3,
+        AES0, AES1, AES2, AES3,
+        LT0, LT1, LT2, LT3, LT4, LT5, LT6, LT7,
+        mixtab0, mixtab1, mixtab2, mixtab3
+    );
     
     unsigned int best_hash = 0;
     for (unsigned int i = 1; i < unit_size; i++) {


### PR DESCRIPTION
## Overview

This PR adapts the [HAC OpenCL GPU miner](https://github.com/hacash/fullnode/pull/36) to also support diamond mining (HACD).

## Implementation Details

Shared algorithm logic has been moved into common files.
The remaining components are organized into separate modules for "pow" and "dia" / "diamonds".

Several files were refactored to support this separation and improve code structure.

## Testing

Tested on Ubuntu and Windows systems with consistent results.

The hashrate is approximately 93% of the HAC miner, as the HACD name calculation performed in each cycle introduces additional computational overhead.

GPU | work_groups | local_size | unit_size | Hashrate
-- | -- | -- | -- | --:
RTX 4070 | 256 | 256 | 128 | ~36Mh/s
RTX 4070 | 2048 | 256 | 256 | ~38Mh/s
RTX 4090 | 2048 | 256 | 256 | ~77Mh/s
RTX 5090 | 2048 | 256 | 256 | ~97Mh/s
RTX 5090 | 2048 | 256 | 512 | ~97Mh/s

## Configuration

The configuration is identical to the HAC miner.
A separate pull request updating hacash/doc will be submitted afterwards.

```
[gpu]
use_opencl = false
work_groups = 1024
local_size = 256
unit_size = 128
opencl_dir = opencl/
platform_id = 0
device_id = 
```